### PR TITLE
Increase refresh time to 1h

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ resource "kubernetes_manifest" "external_secrets" {
       }
     }
     "spec" = {
-      "refreshInterval" = "1m"
+      "refreshInterval" = "1h"
       "secretStoreRef" = {
         "name" = local.secret_store_name
         "kind" = "SecretStore"


### PR DESCRIPTION
The secrets stored in the AWS SM are mostly long lived and not rotated often. If the rotation happened, by deleting the kubernetes_secret will pull the latest value from AWS SM on demand. This PR increases the refresh interval which will reduce the number of API calls the ESO makes to AWS SM for reconcilation