### PR TITLE
remove beta1 from v1beta1 apiVersion

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aws_iam_policy" "irsa_policy" {
 
 resource "kubernetes_manifest" "secret_store" {
   manifest = {
-    "apiVersion" = "external-secrets.io/v1beta1"
+    "apiVersion" = "external-secrets.io/v1"
     "kind"       = "SecretStore"
     "metadata" = {
       "name"      = local.secret_store_name
@@ -107,7 +107,7 @@ resource "kubernetes_manifest" "secret_store" {
 resource "kubernetes_manifest" "external_secrets" {
   for_each = { for k, v in aws_secretsmanager_secret.secret : k => v }
   manifest = {
-    "apiVersion" = "external-secrets.io/v1beta1"
+    "apiVersion" = "external-secrets.io/v1"
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "eks-external-secret-${aws_secretsmanager_secret.secret[each.key].tags["target-k8s-secret-name"]}"


### PR DESCRIPTION
as per the Breaking change for the external secrets operator update to 0.17.0

https://github.com/external-secrets/external-secrets/releases?page=4
v0.17.0 Stops serving v1beta1 apis. You need to update your manifests from v1beta1 to v1 prior to updating from v0.16 to v0.17.
The only change needed is upgrading your manifests to v1 (i.e. removing the beta1 from v1beta1).

 