### PR TITLE
revert apiversion back to v1beta1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aws_iam_policy" "irsa_policy" {
 
 resource "kubernetes_manifest" "secret_store" {
   manifest = {
-    "apiVersion" = "external-secrets.io/v1"
+    "apiVersion" = "external-secrets.io/v1beta1"
     "kind"       = "SecretStore"
     "metadata" = {
       "name"      = local.secret_store_name
@@ -107,7 +107,7 @@ resource "kubernetes_manifest" "secret_store" {
 resource "kubernetes_manifest" "external_secrets" {
   for_each = { for k, v in aws_secretsmanager_secret.secret : k => v }
   manifest = {
-    "apiVersion" = "external-secrets.io/v1"
+    "apiVersion" = "external-secrets.io/v1beta1"
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "eks-external-secret-${aws_secretsmanager_secret.secret[each.key].tags["target-k8s-secret-name"]}"


### PR DESCRIPTION
Reverting the apiversion back to v1beta as user is getting error when deployed PR https://github.com/ministryofjustice/cloud-platform-environments/pull/38890

Build error=https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/18141

This apiversion was changed as part of the external secrets operator update from 0.16.2 to 0.17.0 (eso release from 0.3.0 to 0.4.0) which has also been rolled back
